### PR TITLE
Latest image changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN ln -s /usr/bin/nodejs /usr/bin/node && \
     cp /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/ext/tools.jar && \
     useradd -ms /bin/bash -d /apollo apollo
 
+# RUN cpan notest install Text::Markdown  # needed for apollo release
 ENV WEBAPOLLO_VERSION 75a81df7edc54f4a8e87c9836c9b7c9097d4e4a4
 RUN curl -L https://github.com/GMOD/Apollo/archive/${WEBAPOLLO_VERSION}.tar.gz | tar xzf - --strip-components=1 -C /apollo && \
     chown -R apollo:apollo /apollo

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ To bring down the container:
 
 ## Create the "latest" image
 
-- docker build .
-- docker image # find <image ID>
-- docker tag <image ID> gmod/apollo:latest
-- docker login  --username=maryatdocker --email=mary@docker.com
+- docker build -t gmod/apollo:latest .
+- docker login  --username=<username> --email=<email>
 - docker push gmod/apollo:latest

--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ This procedure starts tomcat in a standard virtualized environment with a Postgr
 To bring down the container:
 - `docker-compose down`
 
-## Create to "latest" image
+## Create the "latest" image
 
-- docker build . 
+- docker build .
 - docker image # find <image ID>
 - docker tag <image ID> gmod/apollo:latest
 - docker login  --username=maryatdocker --email=mary@docker.com
 - docker push gmod/apollo:latest
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     links:
       - "db:db"
     ports:
-      - "8080"
+      - "8080:8080"
     environment:
       WEBAPOLLO_DB_USERNAME: postgres
       WEBAPOLLO_DB_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '2'
 services:
   apollo:
-    image: gmod/apollo:stable
     #build: .
+    image: gmod/apollo:latest
     links:
-      - "apollo_db:db"
+      - "db:db"
     ports:
       - "8080"
     environment:
@@ -15,7 +15,7 @@ services:
       WEBAPOLLO_DB_URI: "jdbc:postgresql://db/postgres"
     volumes:
       - "./data:/data"
-  apollo_db:
+  db:
     image: postgres
     environment:
       POSTGRES_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     #build: .
     image: gmod/apollo:latest
     links:
-      - "db:db"
+      - db
     ports:
       - "8080:8080"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '2'
 services:
   apollo:
-#     build: .
-    image: gmod/apollo:latest
+    image: gmod/apollo:stable
+    #build: .
     links:
-      - db
+      - "apollo_db:db"
     ports:
-      - "8080:8080"
+      - "8080"
     environment:
       WEBAPOLLO_DB_USERNAME: postgres
       WEBAPOLLO_DB_PASSWORD: password
@@ -15,7 +15,7 @@ services:
       WEBAPOLLO_DB_URI: "jdbc:postgresql://db/postgres"
     volumes:
       - "./data:/data"
-  db:
+  apollo_db:
     image: postgres
     environment:
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
- change to hash
- build works perfectly with switching users for bower
- clean up build instructions (tagging is one step)
- [ ] would it be possible to switch to automated builds for https://hub.docker.com/r/gmod/apollo/ ? (You might need to wipe + re-create the repo to be automatically pulled from github)
  - Then we get the benefit of only having to push to this repo, and the image is automatically built.
  - At this point, you might consider whether or not it is worthwhile to include all of this in the gmod/apollo repo, and you could switch back to master, and just adjusting the docker image to checkout a tag in your tagged releases/branches.
