### PR TITLE
Merge chado fix #17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ ENV CONTEXT_PATH ROOT
 # Download chado schema
 RUN wget --quiet https://github.com/erasche/chado-schema-builder/releases/download/1.31-jenkins97/chado-1.31.sql.gz -O /chado.sql.gz && \
 	gunzip /chado.sql.gz
-ADD user.sql /apollo/user.sql
 
 ADD launch.sh /launch.sh
 CMD "/launch.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,15 @@ RUN apt-get -qq update --fix-missing && \
 	postgresql postgresql-client xmlstarlet netcat libpng12-dev \
 	zlib1g-dev libexpat1-dev ant curl ssl-cert
 
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get -qq update --fix-missing && \
 	apt-get --no-install-recommends -y install nodejs && \
 	apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN npm install -g bower && \
-	cp /usr/lib/jvm/java-8-openjdk-amd64/lib/tools.jar /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/tools.jar && \
+RUN cp /usr/lib/jvm/java-8-openjdk-amd64/lib/tools.jar /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/tools.jar && \
 	useradd -ms /bin/bash -d /apollo apollo
 
-ENV WEBAPOLLO_VERSION 7b304aac81f7dab77165f37bf210a6b3cb1b8080
+ENV WEBAPOLLO_VERSION 2d82d5655f65bf58ae50dcb208216a7fec2ecaed
 RUN curl -L https://github.com/GMOD/Apollo/archive/${WEBAPOLLO_VERSION}.tar.gz | tar xzf - --strip-components=1 -C /apollo
 
 

--- a/README.md
+++ b/README.md
@@ -25,16 +25,29 @@ file.
 
 This procedure starts tomcat in a standard virtualized environment with a PostgreSQL database with [Chado](http://gmod.org/wiki/Introduction_to_Chado).
 
-- Install [docker](https://docs.docker.com/engine/installation/) for your system if not previously done.
-- `docker run -it -p 8888:8080 gmod/apollo:2.0.6` # for a tested release
-- `docker run -it -p 8888:8080 gmod/apollo:latest` # for the latest, remember to ```docker pull gmod/apollo``` to fetch newer versions
-- `docker run -it -p 8888:8080 gmod/apollo:apollo-only` # from apollo only (no postgresql)
-- `docker run -it -v /jbrowse/root/directory/:/data -p 8888:8080 gmod/apollo:latest`
-- `docker run -it -v /jbrowse/root/directory/:/data  -p 8888:8080 quay.io/gmod/docker-apollo` # built by quay.io
-- Apollo will be available at [http://localhost:8888/](http://localhost:8888/) (or 8888 if you don't configure the port)
+Install [docker](https://docs.docker.com/engine/installation/) for your system if not previously done.
+
+Choose an option:
+
+- To test a versioned release to test installation: `docker run -it -p 8888:8080 gmod/apollo:2.0.6` 
+
+- Install a latest release to test installation: `docker run -it -p 8888:8080 gmod/apollo:latest` 
+  -  To make sure you have the latest pull with ```docker pull gmod/apollo``` to fetch newer versions
+  
+- If using within a larger context (e.g., as part of a docker-compose script) you can run an ```apollo-only``` branch provides only apollo + tomcat (no PostgreSQL):  
+  - `docker run -it -p 8888:8080 gmod/apollo:apollo-only` 
+  
+- To run in production against JBrowse data and a persistent database (you can create an empty directory called `postgres-data`):  
+    - `docker run -it -v /jbrowse/root/directory/:/data -v postgres-data:/var/lib/postgresql -p 8888:8080 gmod/apollo:latest`
+
+- You can run production using the build created by quay.io (https://quay.io/repository/gmod/docker-apollo):
+    - `docker run -it -v /jbrowse/root/directory/:/data -v postgres-data:/var/lib/postgresql  -v postgres-data:/var/lib/postgresql -p 8888:8080 quay.io/gmod/docker-apollo:latest`
+    
+In all cases, Apollo will be available at [http://localhost:8888/](http://localhost:8888/) (or 8888 if you don't configure the port)
 
 When you use the above mount directory ```/jbrowse/root/directory``` and your genome is in 
 ```/jbrowse/root/directory/myawesomegenome``` you'll point to the directory: ```/data/myawesomegenome```.
+
 
 ### Logging In
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Choose an option:
 - To run in production against JBrowse data and a persistent database (you can create an empty directory called `postgres-data`):  
     - `docker run -it -v /jbrowse/root/directory/:/data -v postgres-data:/var/lib/postgresql -p 8888:8080 gmod/apollo:latest`
 
-- You can run production using the build created by quay.io (https://quay.io/repository/gmod/docker-apollo):
+- You can run production using the build created by quay.io instead (https://quay.io/repository/gmod/docker-apollo):
     - `docker run -it -v /jbrowse/root/directory/:/data -v postgres-data:/var/lib/postgresql  -v postgres-data:/var/lib/postgresql -p 8888:8080 quay.io/gmod/docker-apollo:latest`
     
 In all cases, Apollo will be available at [http://localhost:8888/](http://localhost:8888/) (or 8888 if you don't configure the port)
@@ -48,6 +48,9 @@ In all cases, Apollo will be available at [http://localhost:8888/](http://localh
 When you use the above mount directory ```/jbrowse/root/directory``` and your genome is in 
 ```/jbrowse/root/directory/myawesomegenome``` you'll point to the directory: ```/data/myawesomegenome```.
 
+NOTE: If you don't use a locally mounted PostgreSQL database (e.g., creating an empty directory and mounting using `-v postgres-data:/var/lib/postgresql`)
+or [set appropriate environment variables](https://docs.docker.com/engine/reference/commandline/run/) for a remote database 
+( see variables [defined here](https://github.com/GMOD/docker-apollo/blob/master/launch.sh)) your annotations and setup will not be persisted.
 
 ### Logging In
 

--- a/apollo-config.groovy
+++ b/apollo-config.groovy
@@ -100,7 +100,7 @@ apollo {
 jbrowse {
     git {
         url = "https://github.com/GMOD/jbrowse"
-        tag = "1.12.3-release"
+        tag = "9d765aecaee02a41844fed11a241fdb4c35fc9f8"
     }
     plugins {
         WebApollo{

--- a/apollo-config.groovy
+++ b/apollo-config.groovy
@@ -118,7 +118,6 @@ jbrowse {
         HideTrackLabels{
             included = true
         }
-        // TODO
         GCContent{
             git = 'https://github.com/cmdcolin/GCContent'
             branch = 'master'

--- a/apollo-config.groovy
+++ b/apollo-config.groovy
@@ -11,7 +11,7 @@ environments {
 
             driverClassName = "org.postgresql.Driver"
             dialect = "org.hibernate.dialect.PostgresPlusDialect"
-            url = System.getenv("WEBAPOLLO_DB_URI") ?: "jdbc:postgresql://127.0.0.1/apollo"
+            url = "jdbc:postgresql://${System.getenv("WEBAPOLLO_DB_HOST")?:"127.0.0.1"}/${System.getenv("WEBAPOLLO_DB_NAME")?:"chado"}"
 
             properties {
                 // See http://grails.org/doc/latest/guide/conf.html#dataSource for documentation
@@ -36,12 +36,13 @@ environments {
         }
         dataSource_chado {
             dbCreate = "update"
-            username = "apollo"
-            password = "apollo"
+            username = System.getenv("CHADO_DB_USERNAME") ?: "apollo"
+            password = System.getenv("CHADO_DB_PASSWORD") ?: "apollo"
 
             driverClassName = "org.postgresql.Driver"
             dialect = "org.hibernate.dialect.PostgresPlusDialect"
-            url = "jdbc:postgresql://127.0.0.1/chado"
+
+            url = "jdbc:postgresql://${System.getenv("CHADO_DB_HOST")?:"127.0.0.1"}/${System.getenv("CHADO_DB_NAME")?:"chado"}"
 
             properties {
                 // See http://grails.org/doc/latest/guide/conf.html#dataSource for documentation

--- a/apollo-config.groovy
+++ b/apollo-config.groovy
@@ -11,7 +11,7 @@ environments {
 
             driverClassName = "org.postgresql.Driver"
             dialect = "org.hibernate.dialect.PostgresPlusDialect"
-            url = "jdbc:postgresql://${System.getenv("WEBAPOLLO_DB_HOST")?:"127.0.0.1"}/${System.getenv("WEBAPOLLO_DB_NAME")?:"chado"}"
+            url = "jdbc:postgresql://${System.getenv("WEBAPOLLO_DB_HOST")?:"127.0.0.1"}/${System.getenv("WEBAPOLLO_DB_NAME")?:"apollo"}"
 
             properties {
                 // See http://grails.org/doc/latest/guide/conf.html#dataSource for documentation

--- a/launch.sh
+++ b/launch.sh
@@ -54,12 +54,6 @@ if [[ "$?" == "1" ]]; then
     echo "Loaded Chado"
 fi
 
-
-#export PGUSER=$WEBAPOLLO_DB_USERNAME
-#export PGPASSWORD=$WEBAPOLLO_DB_PASSWORD
-#export PGUSER=$CHADO_DB_USERNAME
-#export PGPASSWORD=$CHADO_DB_PASSWORD
-
 # https://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Naming
 export CATALINA_HOME="${CATALINA_HOME:-/usr/local/tomcat/}"
 FIXED_CTX=$(echo "${CONTEXT_PATH}" | sed 's|/|#|g')

--- a/launch.sh
+++ b/launch.sh
@@ -2,13 +2,11 @@
 service postgresql start
 
 
-echo "Postgres is up, loading chado"
-
 WEBAPOLLO_DB_HOST="${WEBAPOLLO_DB_HOST:-127.0.0.1}"
 WEBAPOLLO_DB_NAME="${WEBAPOLLO_DB_NAME:-apollo}"
 WEBAPOLLO_DB_USERNAME="${WEBAPOLLO_DB_USERNAME:-apollo}"
 WEBAPOLLO_DB_PASSWORD="${WEBAPOLLO_DB_PASSWORD:-apollo}"
-WEBAPOLLO_HOST_FLAG="-h ${WEBAPOLLO_DB_HOST}"
+
 
 # TODO: use variable throughout
 #USE_CHADO="${USE_CHADO:true}"
@@ -17,39 +15,43 @@ CHADO_DB_HOST="${CHADO_DB_HOST:-127.0.0.1}"
 CHADO_DB_NAME="${CHADO_DB_NAME:-chado}"
 CHADO_DB_USERNAME="${CHADO_DB_USERNAME:-apollo}"
 CHADO_DB_PASSWORD="${CHADO_DB_PASSWORD:-apollo}"
-CHADO_HOST_FLAG="-h ${CHADO_DB_HOST}"
 
+if [[ "${WEBAPOLLO_DB_HOST}" != "127.0.0.1" ]]; then
+    WEBAPOLLO_HOST_FLAG="-h ${WEBAPOLLO_DB_HOST}"
+fi
+if [[ "${CHADO_DB_HOST}" != "127.0.0.1" ]]; then
+    CHADO_HOST_FLAG="-h ${CHADO_DB_HOST}"
+fi
 
-#export DB_CONNECT=$(echo $WEBAPOLLO_DB_URI | sed 's/jdbc://g')
-#while ! psql $DB_CONNECT -l; do
-#    echo "Sleeping on DB"
-#    sleep 1;
-#done;
+echo "WEBAPOLLO_HOST_FLAG: $WEBAPOLLO_HOST_FLAG"
+echo "CHADO_HOST_FLAG: $CHADO_HOST_FLAG"
+
 echo "Waiting for DB"
-until pg_isready; do
+until pg_isready $WEBAPOLLO_HOST_FLAG; do
 	echo -n "."
 	sleep 1;
 done
 
 echo "Postgres is up, configuring database"
 
-
-su postgres -c "psql -lqt | cut -d \| -f 1 | grep -qw $WEBAPOLLO_DB_NAME"
+su postgres -c "psql $WEBAPOLLO_HOST_FLAG -lqt | cut -d \| -f 1 | grep -qw $WEBAPOLLO_DB_NAME"
 if [[ "$?" == "1" ]]; then
 	echo "Apollo database not found, creating..."
 	su postgres -c "createdb $WEBAPOLLO_HOST_FLAG $WEBAPOLLO_DB_NAME"
 	su postgres -c "psql $WEBAPOLLO_HOST_FLAG -c \"CREATE USER $WEBAPOLLO_DB_USERNAME WITH PASSWORD '$WEBAPOLLO_DB_PASSWORD';\""
-	su postgres -c "psql $WEBAPOLLO_HOST_FLAG -c 'GRANT ALL PRIVILEGES ON DATABASE \"$WEBAPOLLO_DB_NAME\" to $WEBAPOLLO_DB_USERNAME;'"
+	su postgres -c "psql $WEBAPOLLO_HOST_FLAG -c \"GRANT ALL PRIVILEGES ON DATABASE $WEBAPOLLO_DB_NAME to $WEBAPOLLO_DB_USERNAME;\""
 fi
 
 echo "Configuring Chado"
-su postgres -c "psql -lqt | cut -d \| -f 1 | grep -qw $CHADO_DB_NAME"
+su postgres -c "psql $CHADO_HOST_FLAG -lqt | cut -d \| -f 1 | grep -qw $CHADO_DB_NAME"
 if [[ "$?" == "1" ]]; then
 	echo "Chado database not found, creating..."
 	su postgres -c "createdb $CHADO_HOST_FLAG $CHADO_DB_NAME"
 	su postgres -c "psql $CHADO_HOST_FLAG -c \"CREATE USER $CHADO_DB_USERNAME WITH PASSWORD '$CHADO_DB_PASSWORD';\""
 	su postgres -c "psql $CHADO_HOST_FLAG -c 'GRANT ALL PRIVILEGES ON DATABASE \"$CHADO_DB_NAME\" to $CHADO_DB_USERNAME;'"
-	su postgres -c "psql -U $CHADO_DB_USERNAME -h ${CHADO_DB_HOST} $CHADO_DB_NAME -f /chado.sql"
+    echo "Loading Chado"
+	su postgres -c "PGPASSWORD=$CHADO_DB_PASSWORD psql -U $CHADO_DB_USERNAME -h $CHADO_DB_HOST $CHADO_DB_NAME -f /chado.sql"
+    echo "Loaded Chado Chado"
 fi
 
 

--- a/launch.sh
+++ b/launch.sh
@@ -11,36 +11,18 @@ done
 
 echo "Postgres is up, loading chado"
 
-if [[ "${WEBAPOLLO_DB_HOST}" == "" ]]; then
-	WEBAPOLLO_DB_HOST=127.0.0.1
-fi
-if [[ "${WEBAPOLLO_DB_NAME}" == "" ]]; then
-	WEBAPOLLO_DB_NAME=apollo
-fi
-if [[ "${WEBAPOLLO_DB_USERNAME}" == "" ]]; then
-	WEBAPOLLO_DB_USERNAME=apollo
-fi
-if [[ "${WEBAPOLLO_DB_PASSWORD}" == "" ]]; then
-	WEBAPOLLO_DB_PASSWORD=apollo
-fi
+WEBAPOLLO_DB_HOST="${WEBAPOLLO_DB_HOST:-127.0.0.1}"
+WEBAPOLLO_DB_NAME="${WEBAPOLLO_DB_NAME:-apollo}"
+WEBAPOLLO_DB_USERNAME="${WEBAPOLLO_DB_USERNAME:-apollo}"
+WEBAPOLLO_DB_PASSWORD="${WEBAPOLLO_DB_PASSWORD:-apollo}"
 WEBAPOLLO_HOST_FLAG="-h ${WEBAPOLLO_DB_HOST}"
 
-
-if [[ "${CHADO_DB_HOST}" == "" ]]; then
-	CHADO_DB_HOST=127.0.0.1
-fi
-if [[ "${CHADO_DB_NAME}" == "" ]]; then
-	CHADO_DB_NAME=chado
-fi
-if [[ "${CHADO_DB_USERNAME}" == "" ]]; then
-	CHADO_DB_USERNAME=apollo
-fi
-if [[ "${CHADO_DB_PASSWORD}" == "" ]]; then
-	CHADO_DB_PASSWORD=apollo
-fi
+CHADO_DB_HOST="${CHADO_DB_HOST:-127.0.0.1}"
+CHADO_DB_NAME="${CHADO_DB_NAME:-apollo}"
+CHADO_DB_USERNAME="${CHADO_DB_USERNAME:-apollo}"
+CHADO_DB_PASSWORD="${CHADO_DB_PASSWORD:-apollo}"
 CHADO_HOST_FLAG="-h ${CHADO_DB_HOST}"
 
-su postgres -c 'psql -f /apollo/user.sql'
 
 su postgres -c "psql -lqt | cut -d \| -f 1 | grep -qw $WEBAPOLLO_DB_NAME"
 if [[ "$?" == "1" ]]; then
@@ -53,11 +35,10 @@ fi
 su postgres -c "psql -lqt | cut -d \| -f 1 | grep -qw $CHADO_DB_NAME"
 if [[ "$?" == "1" ]]; then
 	echo "Chado database not found, creating..."
-    su postgres -c "createdb $CHADO_DB_NAME"
 	su postgres -c "createdb $CHADO_HOST_FLAG $CHADO_DB_NAME"
 	su postgres -c "psql $CHADO_HOST_FLAG -c \"CREATE USER $CHADO_DB_USERNAME WITH PASSWORD '$CHADO_DB_PASSWORD';\""
 	su postgres -c "psql $CHADO_HOST_FLAG -c 'GRANT ALL PRIVILEGES ON DATABASE \"$CHADO_DB_NAME\" to $CHADO_DB_USERNAME;'"
-	su postgres -c "PGPASSWORD=apollo psql -U $CHADO_DB_USERNAME -h ${CHADO_DB_HOST} $CHADO_DB_NAME -f /chado.sql"
+	su postgres -c "psql -U $CHADO_DB_USERNAME -h ${CHADO_DB_HOST} $CHADO_DB_NAME -f /chado.sql"
 fi
 
 

--- a/launch.sh
+++ b/launch.sh
@@ -51,7 +51,7 @@ if [[ "$?" == "1" ]]; then
 	su postgres -c "psql $CHADO_HOST_FLAG -c 'GRANT ALL PRIVILEGES ON DATABASE \"$CHADO_DB_NAME\" to $CHADO_DB_USERNAME;'"
     echo "Loading Chado"
 	su postgres -c "PGPASSWORD=$CHADO_DB_PASSWORD psql -U $CHADO_DB_USERNAME -h $CHADO_DB_HOST $CHADO_DB_NAME -f /chado.sql"
-    echo "Loaded Chado Chado"
+    echo "Loaded Chado"
 fi
 
 

--- a/launch.sh
+++ b/launch.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 service postgresql start 
 
-
-
-#!/bin/bash
 until pg_isready; do
 	echo -n "."
 	sleep 1;

--- a/launch.sh
+++ b/launch.sh
@@ -14,14 +14,12 @@ WEBAPOLLO_HOST_FLAG="-h ${WEBAPOLLO_DB_HOST}"
 #USE_CHADO="${USE_CHADO:true}"
 
 CHADO_DB_HOST="${CHADO_DB_HOST:-127.0.0.1}"
-CHADO_DB_NAME="${CHADO_DB_NAME:-apollo}"
+CHADO_DB_NAME="${CHADO_DB_NAME:-chado}"
 CHADO_DB_USERNAME="${CHADO_DB_USERNAME:-apollo}"
 CHADO_DB_PASSWORD="${CHADO_DB_PASSWORD:-apollo}"
 CHADO_HOST_FLAG="-h ${CHADO_DB_HOST}"
 
 
-export PGUSER=$WEBAPOLLO_DB_USERNAME
-export PGPASSWORD=$WEBAPOLLO_DB_PASSWORD
 #export DB_CONNECT=$(echo $WEBAPOLLO_DB_URI | sed 's/jdbc://g')
 #while ! psql $DB_CONNECT -l; do
 #    echo "Sleeping on DB"
@@ -45,8 +43,6 @@ if [[ "$?" == "1" ]]; then
 fi
 
 echo "Configuring Chado"
-export PGUSER=$CHADO_DB_USERNAME
-export PGPASSWORD=$CHADO_DB_PASSWORD
 su postgres -c "psql -lqt | cut -d \| -f 1 | grep -qw $CHADO_DB_NAME"
 if [[ "$?" == "1" ]]; then
 	echo "Chado database not found, creating..."
@@ -56,6 +52,11 @@ if [[ "$?" == "1" ]]; then
 	su postgres -c "psql -U $CHADO_DB_USERNAME -h ${CHADO_DB_HOST} $CHADO_DB_NAME -f /chado.sql"
 fi
 
+
+#export PGUSER=$WEBAPOLLO_DB_USERNAME
+#export PGPASSWORD=$WEBAPOLLO_DB_PASSWORD
+#export PGUSER=$CHADO_DB_USERNAME
+#export PGPASSWORD=$CHADO_DB_PASSWORD
 
 # https://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Naming
 export CATALINA_HOME="${CATALINA_HOME:-/usr/local/tomcat/}"

--- a/launch.sh
+++ b/launch.sh
@@ -10,11 +10,56 @@ until pg_isready; do
 done
 
 echo "Postgres is up, loading chado"
-su postgres -c 'createdb apollo'
-su postgres -c 'createdb chado'
+
+if [[ "${WEBAPOLLO_DB_HOST}" == "" ]]; then
+	WEBAPOLLO_DB_HOST=127.0.0.1
+fi
+if [[ "${WEBAPOLLO_DB_NAME}" == "" ]]; then
+	WEBAPOLLO_DB_NAME=apollo
+fi
+if [[ "${WEBAPOLLO_DB_USERNAME}" == "" ]]; then
+	WEBAPOLLO_DB_USERNAME=apollo
+fi
+if [[ "${WEBAPOLLO_DB_PASSWORD}" == "" ]]; then
+	WEBAPOLLO_DB_PASSWORD=apollo
+fi
+WEBAPOLLO_HOST_FLAG="-h ${WEBAPOLLO_DB_HOST}"
+
+
+if [[ "${CHADO_DB_HOST}" == "" ]]; then
+	CHADO_DB_HOST=127.0.0.1
+fi
+if [[ "${CHADO_DB_NAME}" == "" ]]; then
+	CHADO_DB_NAME=chado
+fi
+if [[ "${CHADO_DB_USERNAME}" == "" ]]; then
+	CHADO_DB_USERNAME=apollo
+fi
+if [[ "${CHADO_DB_PASSWORD}" == "" ]]; then
+	CHADO_DB_PASSWORD=apollo
+fi
+CHADO_HOST_FLAG="-h ${CHADO_DB_HOST}"
+
 su postgres -c 'psql -f /apollo/user.sql'
 
-su postgres -c 'PGPASSWORD=apollo psql -U apollo -h 127.0.0.1 chado -f /chado.sql'
+su postgres -c "psql -lqt | cut -d \| -f 1 | grep -qw $WEBAPOLLO_DB_NAME"
+if [[ "$?" == "1" ]]; then
+	echo "Apollo database not found, creating..."
+	su postgres -c "createdb $WEBAPOLLO_HOST_FLAG $WEBAPOLLO_DB_NAME"
+	su postgres -c "psql $WEBAPOLLO_HOST_FLAG -c \"CREATE USER $WEBAPOLLO_DB_USERNAME WITH PASSWORD '$WEBAPOLLO_DB_PASSWORD';\""
+	su postgres -c "psql $WEBAPOLLO_HOST_FLAG -c 'GRANT ALL PRIVILEGES ON DATABASE \"$WEBAPOLLO_DB_NAME\" to $WEBAPOLLO_DB_USERNAME;'"
+fi
+
+su postgres -c "psql -lqt | cut -d \| -f 1 | grep -qw $CHADO_DB_NAME"
+if [[ "$?" == "1" ]]; then
+	echo "Chado database not found, creating..."
+    su postgres -c "createdb $CHADO_DB_NAME"
+	su postgres -c "createdb $CHADO_HOST_FLAG $CHADO_DB_NAME"
+	su postgres -c "psql $CHADO_HOST_FLAG -c \"CREATE USER $CHADO_DB_USERNAME WITH PASSWORD '$CHADO_DB_PASSWORD';\""
+	su postgres -c "psql $CHADO_HOST_FLAG -c 'GRANT ALL PRIVILEGES ON DATABASE \"$CHADO_DB_NAME\" to $CHADO_DB_USERNAME;'"
+	su postgres -c "PGPASSWORD=apollo psql -U $CHADO_DB_USERNAME -h ${CHADO_DB_HOST} $CHADO_DB_NAME -f /chado.sql"
+fi
+
 
 # https://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Naming
 export CATALINA_HOME=/usr/local/tomcat/
@@ -26,4 +71,9 @@ $CATALINA_HOME/bin/shutdown.sh
 $CATALINA_HOME/bin/startup.sh
 
 cp ${CATALINA_HOME}/apollo.war ${WAR_FILE}
+
+if [[ ! -f "${CATALINA_HOME}/logs/catalina.out" ]]; then
+	touch ${CATALINA_HOME}/logs/catalina.out
+fi
+
 tail -f ${CATALINA_HOME}/logs/catalina.out 

--- a/user.sql
+++ b/user.sql
@@ -1,3 +1,0 @@
-CREATE USER apollo WITH PASSWORD 'apollo';
-GRANT ALL PRIVILEGES ON DATABASE "apollo" to apollo;
-GRANT ALL PRIVILEGES ON DATABASE "chado" to apollo;


### PR DESCRIPTION
This should integrate the important pieces from #17.  

- [ ] add pg_isready for chado, as well
- [ ] copying ROOT.war is unnecessary each time, but should be done after redoing build
- [ ] don't remove or install elsewhere useful binaries (data prep, loading, etc.)
- [ ] remove postgresql launch if non-local? 
- [ ] fork apollo-only to another repository?  (PITA, but better for users?)

===
- [x] evaluate feedback here: https://github.com/erasche/docker-apollo/blob/master/launch.sh#L10
- [x] fix loading bug
- [x] confirm de novo installlation 
- [x] confirm that chado is not re-run
- [x] merge into apollo-only relevant changes
